### PR TITLE
Include LICENSE file in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE


### PR DESCRIPTION
Most distributions require license files to be included in source
tarballs, e.g. [1].

[1] https://fedoraproject.org/wiki/Packaging:LicensingGuidelines#License_Text