### PR TITLE
Show location of deprecation in warning rather than the decorator

### DIFF
--- a/deprecation.py
+++ b/deprecation.py
@@ -180,7 +180,8 @@ def deprecated(deprecated_in=None, removed_in=None, current_version=None,
 
                 the_warning = cls(function.__name__, deprecated_in,
                                   removed_in, details)
-                warnings.warn(the_warning)
+                warnings.warn(the_warning, category=DeprecationWarning,
+                              stacklevel=2)
 
             return function(*args, **kwargs)
         return _inner


### PR DESCRIPTION
With this change the reader sees the file/line info of where the @decorator is used, i.e. the deprecated function/method/class.