### PR TITLE
Retain proper indentation of multiline docstrings

### DIFF
--- a/deprecation.py
+++ b/deprecation.py
@@ -10,6 +10,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 import functools
+import textwrap
 import warnings
 
 from packaging import version
@@ -167,8 +168,35 @@ def deprecated(deprecated_in=None, removed_in=None, current_version=None,
             deprecation_note = ("*Deprecated{deprecated_in}{removed_in}"
                                 "{period}{details}*".format(**parts))
 
-            function.__doc__ = "\n\n".join([existing_docstring,
-                                            deprecation_note])
+            pos = existing_docstring.find("\n")
+
+            if pos != -1:
+                # With a multi-line docstring, when we modify
+                # existing_docstring to add our deprecation_note,
+                # if we're not careful we'll interfere with the
+                # indentation levels of the contents below the
+                # first line, or as PEP 257 calls it, the summary
+                # line. Since the summary line can start on the
+                # same line as the """, dedenting the whole thing
+                # won't help. Split the summary and contents up,
+                # dedent the contents independently, then join
+                # summary, dedent'ed contents, and our
+                # deprecation_note.
+
+                # TODO(briancurtin): If this can ever drop 2.7 support,
+                # PEP 3132 iterable unpacking makes this much easier.
+                # summary, *contents = existing_docstring.splitlines()
+                lines = existing_docstring.splitlines()
+                summary = lines[0]
+                contents = lines[1:]
+
+                contents = "\n".join(contents)
+                function.__doc__ = "\n".join([summary,
+                                              textwrap.dedent(contents),
+                                              deprecation_note])
+            else:
+                function.__doc__ = "\n\n".join([existing_docstring,
+                                                deprecation_note])
 
         @functools.wraps(function)
         def _inner(*args, **kwargs):

--- a/deprecation.py
+++ b/deprecation.py
@@ -188,7 +188,7 @@ def deprecated(deprecated_in=None, removed_in=None, current_version=None,
 
                 function.__doc__ = "".join([summary,
                                             textwrap.dedent(contents),
-                                            "\n",
+                                            "\n\n",
                                             deprecation_note])
             else:
                 function.__doc__ = "\n\n".join([existing_docstring,

--- a/deprecation.py
+++ b/deprecation.py
@@ -183,17 +183,13 @@ def deprecated(deprecated_in=None, removed_in=None, current_version=None,
                 # summary, dedent'ed contents, and our
                 # deprecation_note.
 
-                # TODO(briancurtin): If this can ever drop 2.7 support,
-                # PEP 3132 iterable unpacking makes this much easier.
-                # summary, *contents = existing_docstring.splitlines()
-                lines = existing_docstring.splitlines()
-                summary = lines[0]
-                contents = lines[1:]
+                summary = existing_docstring[:pos]
+                contents = existing_docstring[pos:]
 
-                contents = "\n".join(contents)
-                function.__doc__ = "\n".join([summary,
-                                              textwrap.dedent(contents),
-                                              deprecation_note])
+                function.__doc__ = "".join([summary,
+                                            textwrap.dedent(contents),
+                                            "\n",
+                                            deprecation_note])
             else:
                 function.__doc__ = "\n\n".join([existing_docstring,
                                                 deprecation_note])

--- a/sample.py
+++ b/sample.py
@@ -14,6 +14,19 @@ def won():
     return 1
 
 
+@deprecation.deprecated(deprecated_in="1.0", removed_in="2.0",
+                        current_version=__version__,
+                        details="Use the ``one`` function instead")
+def uno():
+    """Esta función regresa 1
+
+    This is Spanish for 'This function returns 1'
+
+    This is also here to show that multiline docstrings work
+    """
+    return 1
+
+
 def one():
     """This function returns 1"""
     return 1

--- a/tests/test_deprecation.py
+++ b/tests/test_deprecation.py
@@ -43,6 +43,30 @@ class Test_deprecated(unittest2.TestCase):
 
                 self.assertEqual(fn.__doc__, test["__doc__"])
 
+    def test_multiline_docstring(self):
+        docstring = "summary line\n\ndetails\nand more details\n"
+        for test in [{"args": {},
+                      "__doc__": "%s\n*Deprecated*"},
+                     {"args": {"deprecated_in": "1.0"},
+                      "__doc__": "%s\n*Deprecated in 1.0.*"},
+                     {"args": {"deprecated_in": "1.0", "removed_in": "2.0"},
+                      "__doc__": "%s\n*Deprecated in 1.0, "
+                                 "to be removed in 2.0.*"},
+                     {"args": {"deprecated_in": "1.0", "removed_in": "2.0",
+                               "details": "some details"},
+                      "__doc__": "%s\n*Deprecated in 1.0, "
+                                 "to be removed in 2.0. some details*"}]:
+            with self.subTest(**test):
+                @deprecation.deprecated(**test["args"])
+                def fn():
+                    """summary line
+
+                    details
+                    and more details
+                    """
+
+                self.assertEqual(fn.__doc__, test["__doc__"] % docstring)
+
     def test_warning_raised(self):
         ret_val = "lololol"
 

--- a/tests/test_deprecation.py
+++ b/tests/test_deprecation.py
@@ -46,15 +46,15 @@ class Test_deprecated(unittest2.TestCase):
     def test_multiline_docstring(self):
         docstring = "summary line\n\ndetails\nand more details\n"
         for test in [{"args": {},
-                      "__doc__": "%s\n*Deprecated*"},
+                      "__doc__": "%s\n\n*Deprecated*"},
                      {"args": {"deprecated_in": "1.0"},
-                      "__doc__": "%s\n*Deprecated in 1.0.*"},
+                      "__doc__": "%s\n\n*Deprecated in 1.0.*"},
                      {"args": {"deprecated_in": "1.0", "removed_in": "2.0"},
-                      "__doc__": "%s\n*Deprecated in 1.0, "
+                      "__doc__": "%s\n\n*Deprecated in 1.0, "
                                  "to be removed in 2.0.*"},
                      {"args": {"deprecated_in": "1.0", "removed_in": "2.0",
                                "details": "some details"},
-                      "__doc__": "%s\n*Deprecated in 1.0, "
+                      "__doc__": "%s\n\n*Deprecated in 1.0, "
                                  "to be removed in 2.0. some details*"}]:
             with self.subTest(**test):
                 @deprecation.deprecated(**test["args"])


### PR DESCRIPTION
This change fixes an issue where multiline docstrings would have their body contents indented a level beyond where they should have been, causing potential rendering issues with Sphinx and the REPL's builtin `help` functionality.

Rather than blindly joining our deprecation details to the docstring, we now look to see if it's a multiline docstring or not, and if it is, we more carefully append to it. In order to preserve the intended indentation, we split the docstring into its summary line and the rest of the contents, use `textwrap.dedent` on the contents, and then join the summary and contents back up along with the details of the deprecation message so they'll all be on the same level.

This includes a change to sample.py with a multiline docstring example, which the docs will render.

Fixes #10