### PR TITLE
ENH: use `deprecated`-directive in docstring, add `message_location` …

### DIFF
--- a/deprecation.py
+++ b/deprecation.py
@@ -162,7 +162,7 @@ def deprecated(deprecated_in=None, removed_in=None, current_version=None,
                 "deprecated_in":
                     " %s" % deprecated_in if deprecated_in else "",
                 "removed_in":
-                    "\n   To be removed in %s." %
+                    "\n   This will be removed in %s." %
                     removed_in if removed_in else "",
                 "details":
                     " %s" % details if details else ""}

--- a/sample.py
+++ b/sample.py
@@ -16,6 +16,19 @@ def won():
 
 @deprecation.deprecated(deprecated_in="1.0", removed_in="2.0",
                         current_version=__version__,
+                        details="Use the ``multiline_one`` function instead.")
+def multiline_bottom():
+    """This function returns 1.
+
+    Multiline Bottom. Deprecation Note is inserted at the bottom.
+
+    This is also here to show that multiline docstrings work
+    """
+    return 1
+
+
+@deprecation.deprecated(deprecated_in="1.0", removed_in="2.0",
+                        current_version=__version__,
                         details="Use the ``one`` function instead")
 def uno():
     """Esta función regresa 1
@@ -38,6 +51,23 @@ def one():
 def why():
     """This isn't necessary"""
     return None
+
+
+deprecation.message_location = 'top'
+
+
+@deprecation.deprecated(deprecated_in="1.0", removed_in="2.0",
+                        current_version=__version__,
+                        details="Use the ``multiline_one`` function instead.")
+def multiline_top():
+    """This function returns 1.
+
+    Multiline Top. Deprecation Note is inserted above this line. This is done
+    via setting ``deprecation.message_location`` to 'top'.
+
+    This is also here to show that multiline docstrings work
+    """
+    return 1
 
 
 class Tests(unittest2.TestCase):

--- a/tests/test_deprecation.py
+++ b/tests/test_deprecation.py
@@ -26,16 +26,16 @@ class Test_deprecated(unittest2.TestCase):
 
     def test_docstring(self):
         for test in [{"args": {},
-                      "__doc__": "docstring\n\n*Deprecated*"},
+                      "__doc__": "docstring\n\n.. deprecated::"},
                      {"args": {"deprecated_in": "1.0"},
-                      "__doc__": "docstring\n\n*Deprecated in 1.0.*"},
+                      "__doc__": "docstring\n\n.. deprecated:: 1.0"},
                      {"args": {"deprecated_in": "1.0", "removed_in": "2.0"},
-                      "__doc__": "docstring\n\n*Deprecated in 1.0, "
-                                 "to be removed in 2.0.*"},
+                      "__doc__": "docstring\n\n.. deprecated:: 1.0"
+                                 "\n   To be removed in 2.0."},
                      {"args": {"deprecated_in": "1.0", "removed_in": "2.0",
                                "details": "some details"},
-                      "__doc__": "docstring\n\n*Deprecated in 1.0, "
-                                 "to be removed in 2.0. some details*"}]:
+                      "__doc__": "docstring\n\n.. deprecated:: 1.0"
+                                 "\n   To be removed in 2.0. some details"}]:
             with self.subTest(**test):
                 @deprecation.deprecated(**test["args"])
                 def fn():
@@ -46,16 +46,16 @@ class Test_deprecated(unittest2.TestCase):
     def test_multiline_docstring(self):
         docstring = "summary line\n\ndetails\nand more details\n"
         for test in [{"args": {},
-                      "__doc__": "%s\n\n*Deprecated*"},
+                      "__doc__": "%s\n\n.. deprecated::"},
                      {"args": {"deprecated_in": "1.0"},
-                      "__doc__": "%s\n\n*Deprecated in 1.0.*"},
+                      "__doc__": "%s\n\n.. deprecated:: 1.0"},
                      {"args": {"deprecated_in": "1.0", "removed_in": "2.0"},
-                      "__doc__": "%s\n\n*Deprecated in 1.0, "
-                                 "to be removed in 2.0.*"},
+                      "__doc__": "%s\n\n.. deprecated:: 1.0"
+                                 "\n   To be removed in 2.0."},
                      {"args": {"deprecated_in": "1.0", "removed_in": "2.0",
                                "details": "some details"},
-                      "__doc__": "%s\n\n*Deprecated in 1.0, "
-                                 "to be removed in 2.0. some details*"}]:
+                      "__doc__": "%s\n\n.. deprecated:: 1.0"
+                                 "\n   To be removed in 2.0. some details"}]:
             with self.subTest(**test):
                 @deprecation.deprecated(**test["args"])
                 def fn():
@@ -65,7 +65,53 @@ class Test_deprecated(unittest2.TestCase):
                     and more details
                     """
 
-                self.assertEqual(fn.__doc__, test["__doc__"] % docstring)
+                self.assertEqual(fn.__doc__, test["__doc__"] % (docstring))
+
+    def test_multiline_docstring_top(self):
+        summary = "summary line"
+        content = "\n\ndetails\nand more details\n"
+        for test in [{"args": {},
+                      "__doc__": "%s\n\n.. deprecated::%s"},
+                     {"args": {"deprecated_in": "1.0"},
+                      "__doc__": "%s\n\n.. deprecated:: 1.0%s"},
+                     {"args": {"deprecated_in": "1.0", "removed_in": "2.0"},
+                      "__doc__": "%s\n\n.. deprecated:: 1.0"
+                                 "\n   To be removed in 2.0.%s"},
+                     {"args": {"deprecated_in": "1.0", "removed_in": "2.0",
+                               "details": "some details"},
+                      "__doc__": "%s\n\n.. deprecated:: 1.0"
+                                 "\n   To be removed in 2.0. some details"
+                                 "%s"}]:
+            with self.subTest(**test):
+                deprecation.message_location = "top"
+
+                @deprecation.deprecated(**test["args"])
+                def fn():
+                    """summary line
+
+                    details
+                    and more details
+                    """
+
+                self.assertEqual(fn.__doc__, test["__doc__"] % (summary,
+                                                                content))
+
+    def test_multiline_fallback(self):
+        docstring = "summary line\n\ndetails\nand more details\n"
+        for test in [{"args": {"deprecated_in": "1.0"},
+                      "__doc__": "%s\n\n.. deprecated:: 1.0"}]:
+            with self.subTest(**test):
+                deprecation.message_location = "pot"
+
+                @deprecation.deprecated(**test["args"])
+                def fn():
+                    """summary line
+
+                    details
+                    and more details
+                    """
+
+                self.assertEqual(fn.__doc__, test["__doc__"] % (docstring))
 
     def test_warning_raised(self):
         ret_val = "lololol"

--- a/tests/test_deprecation.py
+++ b/tests/test_deprecation.py
@@ -31,11 +31,12 @@ class Test_deprecated(unittest2.TestCase):
                       "__doc__": "docstring\n\n.. deprecated:: 1.0"},
                      {"args": {"deprecated_in": "1.0", "removed_in": "2.0"},
                       "__doc__": "docstring\n\n.. deprecated:: 1.0"
-                                 "\n   To be removed in 2.0."},
+                                 "\n   This will be removed in 2.0."},
                      {"args": {"deprecated_in": "1.0", "removed_in": "2.0",
                                "details": "some details"},
                       "__doc__": "docstring\n\n.. deprecated:: 1.0"
-                                 "\n   To be removed in 2.0. some details"}]:
+                                 "\n   This will be removed in 2.0. "
+                                 "some details"}]:
             with self.subTest(**test):
                 @deprecation.deprecated(**test["args"])
                 def fn():
@@ -51,11 +52,12 @@ class Test_deprecated(unittest2.TestCase):
                       "__doc__": "%s\n\n.. deprecated:: 1.0"},
                      {"args": {"deprecated_in": "1.0", "removed_in": "2.0"},
                       "__doc__": "%s\n\n.. deprecated:: 1.0"
-                                 "\n   To be removed in 2.0."},
+                                 "\n   This will be removed in 2.0."},
                      {"args": {"deprecated_in": "1.0", "removed_in": "2.0",
                                "details": "some details"},
                       "__doc__": "%s\n\n.. deprecated:: 1.0"
-                                 "\n   To be removed in 2.0. some details"}]:
+                                 "\n   This will be removed in 2.0. "
+                                 "some details"}]:
             with self.subTest(**test):
                 @deprecation.deprecated(**test["args"])
                 def fn():
@@ -76,12 +78,12 @@ class Test_deprecated(unittest2.TestCase):
                       "__doc__": "%s\n\n.. deprecated:: 1.0%s"},
                      {"args": {"deprecated_in": "1.0", "removed_in": "2.0"},
                       "__doc__": "%s\n\n.. deprecated:: 1.0"
-                                 "\n   To be removed in 2.0.%s"},
+                                 "\n   This will be removed in 2.0.%s"},
                      {"args": {"deprecated_in": "1.0", "removed_in": "2.0",
                                "details": "some details"},
                       "__doc__": "%s\n\n.. deprecated:: 1.0"
-                                 "\n   To be removed in 2.0. some details"
-                                 "%s"}]:
+                                 "\n   This will be removed in 2.0. "
+                                 "some details%s"}]:
             with self.subTest(**test):
                 deprecation.message_location = "top"
 


### PR DESCRIPTION
…to insert deprecation note at top or bottom of docstring

- This uses the `deprecation`-directive to add the deprecation note to the docstring.

- Via `message_location` you can choose to insert the deprecation note at the top (directly after the summary line, or at the bottom). Defaults to bottom.