### PR TITLE
Remove Python 3.4 from testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
   - "3.7-dev" # 3.7 development branch

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,py36,py35,py34,py27,pypy3,pypy,flake8
+envlist = py37,py36,py35,py27,pypy3,pypy,flake8
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
3.7 is almost out and 3.4 is pretty old. 3.5 or 3.6 seem to be the most common bases in 3.x world anyway.