### PR TITLE
Implement DeprecatedVariable for deprecating module level variables

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,9 +11,10 @@ deprecation
 .. image:: https://codecov.io/gh/briancurtin/deprecation/branch/master/graph/badge.svg
   :target: https://codecov.io/gh/briancurtin/deprecation
 
-The ``deprecation`` library provides a ``deprecated`` decorator and a
-``fail_if_not_removed`` decorator for your tests. Together, the two
-enable the automation of several things:
+The ``deprecation`` library provides a ``deprecated`` decorator,
+``DeprecatedVariable`` class, and a ``fail_if_not_removed`` decorator
+for your tests. Together, the three enable the automation of several
+things:
 
 1. The docstring of a deprecated method gets the deprecation details
    appended to the end of it. If you generate your API docs direct
@@ -49,6 +50,13 @@ Usage
     def foo():
         """Do some stuff"""
         return 1
+
+    MODULE_VARIABLE = deprecation.DeprecatedVariable(
+        deprecated_in="1.0",
+        removed_in="2.0",
+        current_version=__version__,
+        details="Use the VAR variable instead"
+    )
 
 ...but doesn't Python ignore ``DeprecationWarning``?
 ====================================================

--- a/tests/export.py
+++ b/tests/export.py
@@ -1,0 +1,51 @@
+from deprecation import DeprecatedVariable
+
+no_warning = DeprecatedVariable(
+    'no_warning', 'no_warning', deprecated_in="2.0",
+    removed_in="3.0", current_version="1.0"
+)
+
+just_deprecated = DeprecatedVariable(
+    'just_deprecated', 'just_deprecated'
+)
+
+details = DeprecatedVariable(
+    'details', 'details', **{
+        "details": "do something else."
+    }
+)
+
+shows_deprecated = DeprecatedVariable(
+    'shows_deprecated', 'shows_deprecated', **{
+        "deprecated_in": "1.0",
+        "current_version": "2.0"
+    }
+)
+
+removed_shows_deprecated = DeprecatedVariable(
+    'removed_shows_deprecated',
+    'removed_shows_deprecated', **{
+        "deprecated_in": "1.0",
+        "removed_in": "3.0",
+        "current_version": "2.0"
+    }
+)
+
+shows_unsupported = DeprecatedVariable(
+    'shows_unsupported',
+    'shows_unsupported', **{
+        "deprecated_in": "1.0",
+        "removed_in": "2.0",
+        "current_version": "2.0"
+    }
+)
+
+details_shows_unsupported = DeprecatedVariable(
+    'details_shows_unsupported',
+    'details_shows_unsupported', **{
+        "deprecated_in": "1.0",
+        "removed_in": "2.0",
+        "current_version": "2.0",
+        "details": "do something else."
+    }
+)


### PR DESCRIPTION
+ Add class `DeprecatedVariable`
* Abstract warning check into `_get_warning_class()`
* Abstract warning raising into `_warn_user()`
* Abstract docstring wrapping into `_wrap_doctring()`
+ Implement tests for `DeprecatedVariable`
* Update README to mention `DeprecatedVariable`