### PR TITLE
Pass args onto DeprecationWarning initializer

### DIFF
--- a/deprecation.py
+++ b/deprecation.py
@@ -56,7 +56,8 @@ class DeprecatedWarning(DeprecationWarning):
         self.deprecated_in = deprecated_in
         self.removed_in = removed_in
         self.details = details
-        super(DeprecatedWarning, self).__init__()
+        super(DeprecatedWarning, self).__init__(function, deprecated_in,
+                                                removed_in, details)
 
     def __str__(self):
         # Use a defaultdict to give us the empty string

--- a/tests/test_deprecation.py
+++ b/tests/test_deprecation.py
@@ -20,6 +20,11 @@ import deprecation
 
 class Test_deprecated(unittest2.TestCase):
 
+    def test_args_set_on_base_class(self):
+        args = (1, 2, 3, 4)
+        dw = deprecation.DeprecatedWarning(*args)
+        self.assertEqual(dw.args, args)
+
     def test_removing_without_deprecating(self):
         self.assertRaises(TypeError, deprecation.deprecated,
                           deprecated_in=None, removed_in="1.0")


### PR DESCRIPTION
If you tried to access the `args` attribute of `DeprecatedWarning`, which it has via the builtin `DeprecationWarning` base class, it would show an empty tuple. This change corrects that and passes the arguments on.

Fixes #36