### PR TITLE
Comment out non-existent html_static_path in doc

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -96,7 +96,7 @@ html_theme = 'nature'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+# html_static_path = ['_static']
 
 
 # -- Options for HTMLHelp output ------------------------------------------


### PR DESCRIPTION
Fixes WARNING: html_static_path entry 'docs/_static' does not exist