### PR TITLE
Restricting the packaging version to less than 20

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,5 @@
 codecov>=2.0
 coverage>=4.3
 flake8>=3.2
-packaging>=16.8
+packaging>=16.8,<=19.2
 unittest2>=1.1


### PR DESCRIPTION
**OS**: CentOS7
**Python version**: Python2.7

Following would work with `packaging-19.2` version when checked for typehinting using `mypy`
```
from packaging import version
version.parse(u"hello world")
```
But when `packaging-20` is used there is an error originating from `packaging` saying the argument should strictly be a string (`Text`)

This PR is to restrict the `packaging` version to `packaging-19`, since `mypy` checks break automatically with `packaging-20`, which was released on Jan 5th 2020 (https://pypi.org/project/packaging/20.0/)
