### PR TITLE
Fix for `fail_if_not_removed` interfering with pytest

### DIFF
--- a/deprecation.py
+++ b/deprecation.py
@@ -262,6 +262,7 @@ def fail_if_not_removed(method):
     """
     # NOTE(briancurtin): Unless this is named test_inner, nose won't work
     # properly. See Issue #32.
+    @functools.wraps(method)
     def test_inner(*args, **kwargs):
         with warnings.catch_warnings(record=True) as caught_warnings:
             warnings.simplefilter("always")


### PR DESCRIPTION
I added the line `@functools.wraps(method)` to the `fail_if_not_removed` decorator, which should fix https://github.com/briancurtin/deprecation/issues/42

I tested this with the pytest tests for [PyMassSpec](https://github.com/domdfcoding/PyMassSpec)  which were encountering the problem before and the tests proceed as expected when this change is made. 

This change does not appear to interfere with using `fail_if_not_removed` with unittest.