### PR TITLE
Make unittest optional for python3.5+

### DIFF
--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,1 +1,1 @@
-unittest2
+unittest2;python_version<'3.5'

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,4 +2,4 @@ codecov>=2.0
 coverage>=4.3
 flake8>=3.2
 packaging>=16.8
-unittest2>=1.1
+unittest2>=1.1;python_version<'3.5'

--- a/tests/test_deprecation.py
+++ b/tests/test_deprecation.py
@@ -12,7 +12,12 @@
 
 # As we unfortunately support Python 2.7, it lacks TestCase.subTest which
 # is in 3.4+ or in unittest2
-import unittest2
+try:
+    import unittest2
+except ImportError:
+    import unittest
+    unittest2 = unittest
+
 import warnings
 
 import deprecation

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,6 @@ commands = coverage run -m unittest discover
 
 [testenv:docs]
 deps = Sphinx
-       unittest2
+       unittest2;python_version<'3.5'
 changedir = docs
 commands = sphinx-build -W -b html -d {envtmpdir}/doctrees . _build/html


### PR DESCRIPTION
`unittest2` is an unmaintained backport package. Should be conditionally added

closes: https://github.com/briancurtin/deprecation/issues/54